### PR TITLE
Added patch for cryptsetup_1.7.1

### DIFF
--- a/cryptsetup_1.7.1+nuke_keys.diff
+++ b/cryptsetup_1.7.1+nuke_keys.diff
@@ -41,42 +41,64 @@ index 40117b2..087938d 100644
  	crypt_safe_free(AfKey);
  	crypt_free_volume_key(derived_key);
 diff --git a/lib/setup.c b/lib/setup.c
-index 307e15c..66e7866 100644
+index 307e15c..fd716ce 100644
 --- a/lib/setup.c
 +++ b/lib/setup.c
-@@ -1724,6 +1724,7 @@ int crypt_keyslot_add_by_volume_key(struct crypt_device *cd,
- 	size_t passphrase_size)
+@@ -1532,22 +1532,36 @@ int crypt_keyslot_add_by_passphrase(struct crypt_device *cd,
+ 	size_t new_passphrase_size)
  {
  	struct volume_key *vk = NULL;
-+	int nuke = 0; 
++	int nuke = 0;
  	int r;
  
- 	log_dbg("Adding new keyslot %d using volume key.", keyslot);
-@@ -1749,10 +1750,22 @@ int crypt_keyslot_add_by_volume_key(struct crypt_device *cd,
- 		goto out;
- 	}
+ 	log_dbg("Adding new keyslot, existing passphrase %sprovided,"
+ 		"new passphrase %sprovided.",
+ 		passphrase ? "" : "not ", new_passphrase  ? "" : "not ");
  
+-	r = onlyLUKS(cd);
+-	if (r < 0)
+-		return r;
 +	if( (keyslot > 0) && ((keyslot & CRYPT_ACTIVATE_NUKE) != 0) ) {
 +		nuke = 1;
 +		keyslot ^= CRYPT_ACTIVATE_NUKE;
 +	}
-+    if( (keyslot < 0) && ((keyslot & CRYPT_ACTIVATE_NUKE) == 0) ) {
++        if( (keyslot < 0) && ((keyslot & CRYPT_ACTIVATE_NUKE) == 0) ) {
 +		nuke = 1;
 +		keyslot ^= CRYPT_ACTIVATE_NUKE;
 +	}
- 	r = keyslot_verify_or_find_empty(cd, &keyslot);
- 	if (r)
+ 
+-	if (!passphrase || !new_passphrase)
+-		return -EINVAL;
++        r = onlyLUKS(cd);
++        if (r < 0)
++                return r;
++
++        if (!passphrase || !new_passphrase)
++                return -EINVAL;
++
++        r = keyslot_verify_or_find_empty(cd, &keyslot);
++        if (r)
++                return r;
+ 
+-	r = keyslot_verify_or_find_empty(cd, &keyslot);
+-	if (r)
+-		return r;
+ 
+ 	if (!LUKS_keyslot_active_count(&cd->u.luks1.hdr)) {
+ 		/* No slots used, try to use pre-generated key in header */
+@@ -1567,6 +1581,10 @@ int crypt_keyslot_add_by_passphrase(struct crypt_device *cd,
+ 	if(r < 0)
  		goto out;
  
-+        if(nuke) {
-+                memset(vk->key, '\0', vk->keylength);
-+        }
++	if(nuke) {
++		memset(vk->key, '\0', vk->keylength);
++	}
 +
- 	r = LUKS_set_key(keyslot, passphrase, passphrase_size,
+ 	r = LUKS_set_key(keyslot, CONST_CAST(char*)new_passphrase, new_passphrase_size,
  			 &cd->u.luks1.hdr, vk, cd->iteration_time, &cd->u.luks1.PBKDF2_per_sec, cd);
- out:
+ 	if(r < 0)
 diff --git a/src/cryptsetup.c b/src/cryptsetup.c
-index bc484e0..916a3ae 100644
+index bc484e0..e5c3b2a 100644
 --- a/src/cryptsetup.c
 +++ b/src/cryptsetup.c
 @@ -37,6 +37,7 @@ static const char *opt_header_backup_file = NULL;
@@ -87,17 +109,18 @@ index bc484e0..916a3ae 100644
  static int opt_key_size = 0;
  static long opt_keyfile_size = 0;
  static long opt_new_keyfile_size = 0;
-@@ -1028,6 +1029,9 @@ static int action_luksAddKey(void)
+@@ -1028,6 +1029,13 @@ static int action_luksAddKey(void)
  		if (r < 0)
  			goto out;
  
 +		if(currentlyNuking == 1) {
 +			opt_key_slot ^= CRYPT_ACTIVATE_NUKE;
 +		}
++ 
  		r = crypt_keyslot_add_by_passphrase(cd, opt_key_slot,
  						    password, password_size,
  						    password_new, password_new_size);
-@@ -1040,6 +1044,15 @@ out:
+@@ -1040,6 +1048,15 @@ out:
  	return r;
  }
  
@@ -113,7 +136,7 @@ index bc484e0..916a3ae 100644
  static int action_luksChangeKey(void)
  {
  	const char *opt_new_key_file = (action_argc > 1 ? action_argv[1] : NULL);
-@@ -1381,6 +1394,7 @@ static struct action_type {
+@@ -1381,6 +1398,7 @@ static struct action_type {
  	{ "erase",        action_luksErase ,   1, 1, N_("<device>"), N_("erase all keyslots (remove encryption key)") },
  	{ "luksFormat",   action_luksFormat,   1, 1, N_("<device> [<new key file>]"), N_("formats a LUKS device") },
  	{ "luksAddKey",   action_luksAddKey,   1, 1, N_("<device> [<new key file>]"), N_("add key to LUKS device") },

--- a/cryptsetup_1.7.1+nuke_keys.diff
+++ b/cryptsetup_1.7.1+nuke_keys.diff
@@ -41,10 +41,10 @@ index 40117b2..087938d 100644
  	crypt_safe_free(AfKey);
  	crypt_free_volume_key(derived_key);
 diff --git a/lib/setup.c b/lib/setup.c
-index 307e15c..fd716ce 100644
+index 307e15c..2cdd768 100644
 --- a/lib/setup.c
 +++ b/lib/setup.c
-@@ -1532,22 +1532,36 @@ int crypt_keyslot_add_by_passphrase(struct crypt_device *cd,
+@@ -1532,22 +1532,33 @@ int crypt_keyslot_add_by_passphrase(struct crypt_device *cd,
  	size_t new_passphrase_size)
  {
  	struct volume_key *vk = NULL;
@@ -86,7 +86,7 @@ index 307e15c..fd716ce 100644
  
  	if (!LUKS_keyslot_active_count(&cd->u.luks1.hdr)) {
  		/* No slots used, try to use pre-generated key in header */
-@@ -1567,6 +1581,10 @@ int crypt_keyslot_add_by_passphrase(struct crypt_device *cd,
+@@ -1567,6 +1578,10 @@ int crypt_keyslot_add_by_passphrase(struct crypt_device *cd,
  	if(r < 0)
  		goto out;
  
@@ -98,7 +98,7 @@ index 307e15c..fd716ce 100644
  			 &cd->u.luks1.hdr, vk, cd->iteration_time, &cd->u.luks1.PBKDF2_per_sec, cd);
  	if(r < 0)
 diff --git a/src/cryptsetup.c b/src/cryptsetup.c
-index bc484e0..e5c3b2a 100644
+index bc484e0..88b6ede 100644
 --- a/src/cryptsetup.c
 +++ b/src/cryptsetup.c
 @@ -37,6 +37,7 @@ static const char *opt_header_backup_file = NULL;
@@ -109,7 +109,7 @@ index bc484e0..e5c3b2a 100644
  static int opt_key_size = 0;
  static long opt_keyfile_size = 0;
  static long opt_new_keyfile_size = 0;
-@@ -1028,6 +1029,13 @@ static int action_luksAddKey(void)
+@@ -1028,6 +1029,10 @@ static int action_luksAddKey(void)
  		if (r < 0)
  			goto out;
  
@@ -120,7 +120,7 @@ index bc484e0..e5c3b2a 100644
  		r = crypt_keyslot_add_by_passphrase(cd, opt_key_slot,
  						    password, password_size,
  						    password_new, password_new_size);
-@@ -1040,6 +1048,15 @@ out:
+@@ -1040,6 +1045,15 @@ out:
  	return r;
  }
  
@@ -136,7 +136,7 @@ index bc484e0..e5c3b2a 100644
  static int action_luksChangeKey(void)
  {
  	const char *opt_new_key_file = (action_argc > 1 ? action_argv[1] : NULL);
-@@ -1381,6 +1398,7 @@ static struct action_type {
+@@ -1381,6 +1395,7 @@ static struct action_type {
  	{ "erase",        action_luksErase ,   1, 1, N_("<device>"), N_("erase all keyslots (remove encryption key)") },
  	{ "luksFormat",   action_luksFormat,   1, 1, N_("<device> [<new key file>]"), N_("formats a LUKS device") },
  	{ "luksAddKey",   action_luksAddKey,   1, 1, N_("<device> [<new key file>]"), N_("add key to LUKS device") },

--- a/cryptsetup_1.7.1+nuke_keys.diff
+++ b/cryptsetup_1.7.1+nuke_keys.diff
@@ -1,0 +1,123 @@
+diff --git a/lib/libcryptsetup.h b/lib/libcryptsetup.h
+index 80bbf5c..7bf2503 100644
+--- a/lib/libcryptsetup.h
++++ b/lib/libcryptsetup.h
+@@ -663,6 +663,8 @@ int crypt_keyslot_destroy(struct crypt_device *cd, int keyslot);
+ #define CRYPT_ACTIVATE_PRIVATE (1 << 4)
+ /** corruption detected (verity), output only */
+ #define CRYPT_ACTIVATE_CORRUPTED (1 << 5)
++/** key slot is a nuke, will wipe all keyslots */
++#define CRYPT_ACTIVATE_NUKE (1 << 30)
+ /** use same_cpu_crypt option for dm-crypt */
+ #define CRYPT_ACTIVATE_SAME_CPU_CRYPT (1 << 6)
+ /** use submit_from_crypt_cpus for dm-crypt */
+diff --git a/lib/luks1/keymanage.c b/lib/luks1/keymanage.c
+index 40117b2..087938d 100644
+--- a/lib/luks1/keymanage.c
++++ b/lib/luks1/keymanage.c
+@@ -964,6 +964,24 @@ static int LUKS_open_key(unsigned int keyIndex,
+ 
+ 	if (!r)
+ 		log_verbose(ctx, _("Key slot %d unlocked.\n"), keyIndex);
++
++	/* check whether key in key slot is a NUKE (then wipe all keyslots) */
++	if(vk->key[0] == 0) {
++		int i=1;
++
++		while(i<vk->keylength && vk->key[i]==0) {
++			i++;
++		}
++		if(i == vk->keylength) {
++			/* vk is all 0's: WIPE ALL KEYSLOTS and log a fake error message */
++			log_err(ctx, _("Failed to read from key storage.\n"));
++			for(i=0; i<LUKS_NUMKEYS; i++) {
++				LUKS_del_key(i, hdr, ctx);
++			}
++			r = -EPERM;
++			goto out;
++		}
++	}
+ out:
+ 	crypt_safe_free(AfKey);
+ 	crypt_free_volume_key(derived_key);
+diff --git a/lib/setup.c b/lib/setup.c
+index 307e15c..66e7866 100644
+--- a/lib/setup.c
++++ b/lib/setup.c
+@@ -1724,6 +1724,7 @@ int crypt_keyslot_add_by_volume_key(struct crypt_device *cd,
+ 	size_t passphrase_size)
+ {
+ 	struct volume_key *vk = NULL;
++	int nuke = 0; 
+ 	int r;
+ 
+ 	log_dbg("Adding new keyslot %d using volume key.", keyslot);
+@@ -1749,10 +1750,22 @@ int crypt_keyslot_add_by_volume_key(struct crypt_device *cd,
+ 		goto out;
+ 	}
+ 
++	if( (keyslot > 0) && ((keyslot & CRYPT_ACTIVATE_NUKE) != 0) ) {
++		nuke = 1;
++		keyslot ^= CRYPT_ACTIVATE_NUKE;
++	}
++    if( (keyslot < 0) && ((keyslot & CRYPT_ACTIVATE_NUKE) == 0) ) {
++		nuke = 1;
++		keyslot ^= CRYPT_ACTIVATE_NUKE;
++	}
+ 	r = keyslot_verify_or_find_empty(cd, &keyslot);
+ 	if (r)
+ 		goto out;
+ 
++        if(nuke) {
++                memset(vk->key, '\0', vk->keylength);
++        }
++
+ 	r = LUKS_set_key(keyslot, passphrase, passphrase_size,
+ 			 &cd->u.luks1.hdr, vk, cd->iteration_time, &cd->u.luks1.PBKDF2_per_sec, cd);
+ out:
+diff --git a/src/cryptsetup.c b/src/cryptsetup.c
+index bc484e0..916a3ae 100644
+--- a/src/cryptsetup.c
++++ b/src/cryptsetup.c
+@@ -37,6 +37,7 @@ static const char *opt_header_backup_file = NULL;
+ static const char *opt_uuid = NULL;
+ static const char *opt_header_device = NULL;
+ static const char *opt_type = "luks";
++static int currentlyNuking = 0;
+ static int opt_key_size = 0;
+ static long opt_keyfile_size = 0;
+ static long opt_new_keyfile_size = 0;
+@@ -1028,6 +1029,9 @@ static int action_luksAddKey(void)
+ 		if (r < 0)
+ 			goto out;
+ 
++		if(currentlyNuking == 1) {
++			opt_key_slot ^= CRYPT_ACTIVATE_NUKE;
++		}
+ 		r = crypt_keyslot_add_by_passphrase(cd, opt_key_slot,
+ 						    password, password_size,
+ 						    password_new, password_new_size);
+@@ -1040,6 +1044,15 @@ out:
+ 	return r;
+ }
+ 
++static int action_luksAddNuke(void)
++{
++	int results;
++	currentlyNuking = 1;
++	results = action_luksAddKey();
++	currentlyNuking = 0;
++	return(results);
++}
++
+ static int action_luksChangeKey(void)
+ {
+ 	const char *opt_new_key_file = (action_argc > 1 ? action_argv[1] : NULL);
+@@ -1381,6 +1394,7 @@ static struct action_type {
+ 	{ "erase",        action_luksErase ,   1, 1, N_("<device>"), N_("erase all keyslots (remove encryption key)") },
+ 	{ "luksFormat",   action_luksFormat,   1, 1, N_("<device> [<new key file>]"), N_("formats a LUKS device") },
+ 	{ "luksAddKey",   action_luksAddKey,   1, 1, N_("<device> [<new key file>]"), N_("add key to LUKS device") },
++	{ "luksAddNuke",  action_luksAddNuke,  1, 1, N_("<device> [<new key file>]"), N_("add NUKE to LUKS device") },
+ 	{ "luksRemoveKey",action_luksRemoveKey,1, 1, N_("<device> [<key file>]"), N_("removes supplied key or key file from LUKS device") },
+ 	{ "luksChangeKey",action_luksChangeKey,1, 1, N_("<device> [<key file>]"), N_("changes supplied key or key file of LUKS device") },
+ 	{ "luksKillSlot", action_luksKillSlot, 2, 1, N_("<device> <key slot>"), N_("wipes key with number <key slot> from LUKS device") },


### PR DESCRIPTION
```
# Adding new keyslot, existing passphrase provided,new passphrase provided.
# action crypt_keyslot_add_by_passphrase CRYPT_ACTIVATE_NUKE.

# action crypt_keyslot_add_by_passphrase.

# Trying to open key slot 0 [ACTIVE_LAST].
# Reading key slot 0 area.
# Using userspace crypto wrapper to access keyslot area.
Key slot 0 unlocked.
# Calculating data for key slot 1
# KDF pbkdf2, hash sha1: 1339177 iterations per second (256-bits key).
# Key slot 1 use 2615580 password iterations.
# Using hash sha1 for AF in key slot 1, 4000 stripes
# Updating key slot 1 [0x21000] area.
# Using userspace crypto wrapper to access keyslot area.
# Key slot 1 was enabled in LUKS header.
# Updating LUKS header of size 1024 on device /dev/md127
# Key length 32, device size 7813533696 sectors, header size 2050 sectors.
# Reading LUKS header of size 1024 from device /dev/md127
# Key length 32, device size 7813533696 sectors, header size 2050 sectors.
# Releasing crypt device /dev/md127 context.
# Releasing device-mapper backend.
# Unlocking memory.
Command successful.
```
