### PR TITLE
Add automated tests

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -1,0 +1,184 @@
+#!/bin/bash
+
+
+### Convenience functions
+
+if tty -s; then
+	info_prefix="\x1b[33m>>>\x1b[0m"
+	fail_prefix="\x1b[31mTEST FAILED:\x1b[0m"
+	success_msg="\x1b[32mALL TESTS PASSED!\x1b[0m"
+else
+	info_prefix=">>>"
+	fail_prefix="TEST FAILED:"
+	success_msg="ALL TESTS PASSED!"
+fi
+
+step() {
+	printf "$info_prefix %s...\n" "$*"
+}
+
+fail() {
+	printf "$fail_prefix %s!\n" "$*" >&2
+	[ -n "$BREAK" ] && ( cd $tmpdir && ${SHELL:-bash} -i; )
+	exit 1
+}
+
+success() {
+	echo -e "$success_msg"
+	exit 0
+}
+
+v() {
+	if [ -n "$VERBOSE" ]; then
+		echo "$@" >&2
+	fi
+	"$@"
+}
+
+### Ensure we clean up after ourselves
+
+tmpdir=
+devname="luks-test-$RANDOM"
+dm_target="/dev/mapper/$devname"
+cleanup() {
+	[ -b "$dm_target" ] && cryptsetup close "$devname"
+	[ -d "$tmpdir" ] && rm -rf "$tmpdir"
+}
+trap cleanup EXIT
+
+
+### Run some basic functional tests
+
+tmpdir=$(mktemp -d) \
+|| fail 'unable to make tmp dir'
+
+disk="$tmpdir/disk"
+header="$tmpdir/header"
+secrets="$tmpdir/secrets"
+secrets_blocks='bs=1M count=1'
+
+password=hunter2 # ;)
+nuke=123456
+
+create_disk() {
+	step 'Making a temporary "disk" for testing'
+	v truncate -s 8M "$disk" \
+	  || fail 'unable to make test disk'
+}
+
+create_secrets() {
+	step 'Creating some dummy secret data'
+	v dd if=/dev/urandom of="$secrets" $secrets_blocks && test -s "$secrets" \
+	  || fail 'unable to create secrets file'
+}
+
+luksFormat() {
+	step 'Initializing LUKS container'
+	v cryptsetup luksFormat "$disk" <<< "$password" \
+	  || fail 'unable to format LUKS container'
+}
+
+luksOpen() {
+	step 'Opening with correct passphrase'
+	v cryptsetup luksOpen "$disk" "$devname" <<< "$password" \
+	  && test -b "$dm_target" \
+	  || fail 'disk failed to open'
+}
+
+luksOpen_fail() {
+	step 'Opening with correct passphrase, expecting failure'
+	! v cryptsetup luksOpen "$disk" "$devname" <<< "$password" \
+	  || fail "disk opened when it shouldn't have been able to!"
+}
+
+luksOpen_wrong() {
+	step 'Trying to open with wrong passphrase'
+	! v cryptsetup luksOpen "$disk" "$devname" <<< "wrong $password" \
+	  || fail 'disk opened with wrong passphrase!?'
+}
+
+luksOpen_nuke() {
+	step 'Opening with nuke passphrase'
+	! v cryptsetup luksOpen "$disk" "$devname" <<< "$nuke" \
+	  || fail 'luksOpen with nuke passphrase exited zero!?'
+}
+
+luksClose() {
+	step 'Closing LUKS container'
+	v cryptsetup close "$devname" \
+	  || fail 'unable to close LUKS container'
+}
+
+luksHeaderBackup() {
+	step 'Making header backup'
+	v cryptsetup luksHeaderBackup "$disk" --header-backup-file "$header" \
+	  || fail 'unable to make LUKS header backup'
+}
+
+luksHeaderRestore() {
+	step 'Restoring header backup'
+	# stdin from /dev/null to not ask "Are you sure? (Type uppercase yes):"
+	v cryptsetup luksHeaderRestore "$disk" --header-backup-file "$header" \
+	  </dev/null \
+	  || fail 'unable to restore LUKS header backup'
+}
+
+luksAddNuke() {
+	step 'Adding nuke key'
+	v cryptsetup --key-file <(echo -n "$password") \
+		luksAddNuke "$disk" <<< "$nuke" \
+	  || fail 'failed to add nuke key'
+}
+
+has_key() {
+	v cryptsetup luksDump disk | v grep -xq 'Key Slot [0-9]*: ENABLED'
+}
+
+verify_has_key() {
+	step 'Making sure there exists at least one key slot'
+	has_key || fail 'there are no key slots'
+}
+
+verify_no_keys() {
+	step 'Making sure there are no key slots'
+	! has_key || fail 'there are no key slots'
+}
+
+write_secrets() {
+	step 'Writing secret data into LUKS container'
+	v dd if="$secrets" of="$dm_target" conv=nocreat \
+	  || fail 'unable to copy secrets into LUKS container'
+}
+
+verify_secrets() {
+	step 'Verifying secret data in LUKS container'
+	v diff -u --label 'expected-secrets' --label 'found-secrets' \
+	  <(dd if="$secrets" $secrets_blocks | hexdump -C | head; echo ...) \
+	  <(dd if="$dm_target" $secrets_blocks | hexdump -C | head; echo ...) \
+	  || fail 'Secrets differ!'
+}
+
+create_disk
+create_secrets
+luksFormat
+luksOpen_wrong
+luksOpen
+write_secrets
+verify_secrets
+luksClose
+luksHeaderBackup
+luksAddNuke
+luksOpen
+verify_secrets
+luksClose
+verify_has_keys
+luksOpen_nuke
+verify_no_keys
+luksOpen_fail
+luksHeaderRestore
+verify_has_keys
+luksOpen
+verify_secrets
+luksClose
+
+success

--- a/test.sh
+++ b/test.sh
@@ -100,6 +100,7 @@ luksOpen_wrong() {
 luksOpen_nuke() {
 	step 'Opening with nuke passphrase'
 	! v cryptsetup luksOpen "$disk" "$devname" <<< "$nuke" \
+	  && ! test -e "$dm_target" \
 	  || fail 'luksOpen with nuke passphrase exited zero!?'
 }
 

--- a/test.sh
+++ b/test.sh
@@ -13,13 +13,17 @@ else
 	success_msg="ALL TESTS PASSED!"
 fi
 
+break_to_shell() {
+	( cd $tmpdir && ${SHELL:-bash} -i; )
+}
+
 step() {
 	printf "$info_prefix %s...\n" "$*"
 }
 
 fail() {
 	printf "$fail_prefix %s!\n" "$*" >&2
-	[ -n "$BREAK" ] && ( cd $tmpdir && ${SHELL:-bash} -i; )
+	[ -n "$BREAK" ] && break_to_shell
 	exit 1
 }
 


### PR DESCRIPTION
Example output:

```
% VERBOSE=1 BREAK=1 ./test.sh 
>>> Making a temporary "disk" for testing...
truncate -s 8M /tmp/tmp.gUz94xPebl/disk
>>> Creating some dummy secret data...
dd if=/dev/urandom of=/tmp/tmp.gUz94xPebl/secrets bs=1M count=1
1+0 records in
1+0 records out
1048576 bytes (1.0 MB, 1.0 MiB) copied, 0.00651684 s, 161 MB/s
>>> Initializing LUKS container...
cryptsetup luksFormat /tmp/tmp.gUz94xPebl/disk
>>> Trying to open with wrong passphrase...
cryptsetup luksOpen /tmp/tmp.gUz94xPebl/disk luks-test-32391
No key available with this passphrase.
>>> Opening with correct passphrase...
cryptsetup luksOpen /tmp/tmp.gUz94xPebl/disk luks-test-32391
>>> Writing secret data into LUKS container...
dd if=/tmp/tmp.gUz94xPebl/secrets of=/dev/mapper/luks-test-32391 conv=nocreat
2048+0 records in
2048+0 records out
1048576 bytes (1.0 MB, 1.0 MiB) copied, 0.00794061 s, 132 MB/s
>>> Verifying secret data in LUKS container...
diff -u --label expected-secrets --label found-secrets /dev/fd/63 /dev/fd/62
>>> Closing LUKS container...
cryptsetup close luks-test-32391
>>> Making header backup...
cryptsetup luksHeaderBackup /tmp/tmp.gUz94xPebl/disk --header-backup-file /tmp/tmp.gUz94xPebl/header
>>> Adding nuke key...
cryptsetup --key-file /dev/fd/63 luksAddNuke /tmp/tmp.gUz94xPebl/disk
>>> Opening with correct passphrase...
cryptsetup luksOpen /tmp/tmp.gUz94xPebl/disk luks-test-32391
>>> Verifying secret data in LUKS container...
diff -u --label expected-secrets --label found-secrets /dev/fd/63 /dev/fd/62
>>> Closing LUKS container...
cryptsetup close luks-test-32391
./test.sh: line 174: verify_has_keys: command not found
>>> Opening with nuke passphrase...
cryptsetup luksOpen /tmp/tmp.gUz94xPebl/disk luks-test-32391
Failed to read from key storage.
No key available with this passphrase.
>>> Making sure there are no key slots...
cryptsetup luksDump disk
grep -xq Key Slot [0-9]*: ENABLED
Device disk doesn't exist or access denied.
>>> Opening with correct passphrase, expecting failure...
cryptsetup luksOpen /tmp/tmp.gUz94xPebl/disk luks-test-32391
No key available with this passphrase.
>>> Restoring header backup...
cryptsetup luksHeaderRestore /tmp/tmp.gUz94xPebl/disk --header-backup-file /tmp/tmp.gUz94xPebl/header
./test.sh: line 179: verify_has_keys: command not found
>>> Opening with correct passphrase...
cryptsetup luksOpen /tmp/tmp.gUz94xPebl/disk luks-test-32391
>>> Verifying secret data in LUKS container...
diff -u --label expected-secrets --label found-secrets /dev/fd/63 /dev/fd/62
>>> Closing LUKS container...
cryptsetup close luks-test-32391
ALL TESTS PASSED!
```